### PR TITLE
ツイート削除できるようにした

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -41,23 +41,31 @@ class TweetController extends Controller
     /**
      * ツイート詳細を表示する
      */
-
     public function findByTweetId(int $tweetId): View
     {
-        $tweet = new Tweet();
-        $tweetInfo = $tweet->findByTweetId($tweetId);
+        $tweetModel = new Tweet();
+        $tweet = $tweetModel->findByTweetId($tweetId);
 
-        return view('tweets.show', compact('tweetInfo'));
+        return view('tweets.show', compact('tweet'));
     }
 
     /**
      * ツイートを更新する
      */
-
     public function update(CreateTweetRequest $request, int $tweetId): RedirectResponse
     {
         $tweet = new Tweet();
         $tweet->updateTweet($tweetId, $request);
+        return redirect()->route('tweets.index');
+    }
+
+    /**
+     * ツイート削除する
+     */
+    public function delete(int $tweetId): RedirectResponse
+    {
+        $tweet = new Tweet();
+        $tweet->deleteTweet($tweetId);
         return redirect()->route('tweets.index');
     }
 }

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -32,7 +32,7 @@ class UserController extends Controller
     public function delete(int $userId): RedirectResponse
     {
         $user = new User();
-        $user->userDelete($userId);
+        $user->deleteUser($userId);
         return redirect()->route('home');
     }
 

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -29,9 +29,10 @@ class UserController extends Controller
         return redirect()->route('users.show', ['id' => $userId]);
     }
 
-    public function delete(int $userId)
+    public function delete(int $userId): RedirectResponse
     {
-        User::find($userId)->delete();
+        $user = new User();
+        $user->userDelete($userId);
         return redirect()->route('home');
     }
 

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -7,10 +7,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
 
 class Tweet extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     /**
      * ユーザーデーブルとリレーションをはる
@@ -58,5 +60,14 @@ class Tweet extends Model
         $tweetInfo = $this->findByTweetId($tweetId);
         $tweetInfo->tweet = $request->tweet;
         $tweetInfo->save();
+    }
+
+    /**
+     * ツイート削除
+     */
+    public function deleteTweet(int $tweetId): void
+    {
+        $tweet = $this->findByTweetId($tweetId);
+        $tweet->delete();
     }
 }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -94,9 +94,9 @@ class User extends Authenticatable
     /**
      * ユーザー削除する。
      */
-    public function userDelete($userId): void
+    public function deleteUser($userId): void
     {
         $user = $this->findByUserId($userId);
-        $user -> delete();
+        $user->delete();
     }
 }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -90,4 +90,13 @@ class User extends Authenticatable
         $allUsers = User::all()->sortByDesc('created_at');
         return $allUsers;
     }
+
+    /**
+     * ユーザー削除する。
+     */
+    public function userDelete($userId): void
+    {
+        $user = $this->findByUserId($userId);
+        $user -> delete();
+    }
 }

--- a/twitter/database/migrations/2023_06_28_190132_create_tweets_table.php
+++ b/twitter/database/migrations/2023_06_28_190132_create_tweets_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->unsignedBigInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users');
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/twitter/resources/views/components/tweet-card.blade.php
+++ b/twitter/resources/views/components/tweet-card.blade.php
@@ -1,0 +1,66 @@
+
+<div class="card tweet-card text-dark bg-light mb-3">
+    <div class="card-body">
+        <p class="card-title fw-bolder">{{ $tweet->user->name}}<span class="text-secondary">{{ $tweet->created_at }}</span></p>
+        <p class="card-text">
+            {{ $tweet->tweet }}
+            @if ($tweet->updated_at != $tweet->created_at)
+            <small class="text-secondary">（編集済み）</small>
+            @endif
+        </p>
+    </div>
+    @if (Auth::id() === $tweet->user->id)
+    <div class="tweet-dropdown">
+        <a class="dots-leader" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="true">
+        </a>
+
+        <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+            <li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#test-modal-{{ $tweet->id }}" href="#">編集する</a></li>
+            <li><a class="dropdown-item text-danger" data-bs-toggle="modal" data-bs-target="#delete-modal-{{ $tweet->id }}" href="#">削除する</a></li>
+        </ul>
+    </div>
+    <!-- 編集用のモーダル -->
+    <div id="test-modal-{{ $tweet->id }}" class="modal fade" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content update-modal">
+                <div class="modal-header">
+                    <h5 class="modal-title">ツイート編集</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="update-{{ $tweet->id }}" method="POST" action="{{ route('tweets.update', $tweet->id) }}">
+                        @csrf
+                        <textarea class="tweet-textarea" type="text" id="tweet" name="tweet">{{ $tweet->tweet }}</textarea>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+                    <button type="submit" form="update-{{ $tweet->id }}" class="btn btn-primary" data-bs-dismiss="modal">更新する</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- 削除用のモーダル -->
+    <div class="modal fade" id="delete-modal-{{ $tweet->id }}" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="exampleModalLabel">ツイート削除</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    ツイートを削除してよろしいですか？
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+                    <button type="submit" form="delete-{{ $tweet->id }}" class="btn btn-danger" data-bs-dismiss="modal">削除する</button>
+                    <form id="delete-{{ $tweet->id }}" class="btn" action="{{ route('tweets.delete', ['id' => $tweet->id]) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    @endif
+</div>

--- a/twitter/resources/views/tweets/index.blade.php
+++ b/twitter/resources/views/tweets/index.blade.php
@@ -5,51 +5,8 @@
     <h1>ツイート一覧</h1>
     @foreach ($allTweets as $tweet)
     <a class="text-decoration-none tweet-card-link" href="{{ route('tweets.show', ['id' => $tweet->id]) }}">
-
-        <div class="card tweet-card text-dark bg-light mb-3">
-            <div class="card-body">
-                <p class="card-title fw-bolder">{{ $tweet->user->name}}<span class="text-secondary">{{ $tweet->created_at }}</span></p>
-                <p class="card-text">
-                    {{ $tweet->tweet }}
-                    @if ($tweet->updated_at != $tweet->created_at)
-                    <small class="text-secondary">（編集済み）</small>
-                    @endif
-                </p>
-            </div>
-            @if (Auth::id() === $tweet->user->id)
-            <div class="tweet-dropdown">
-                <a class="dots-leader" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="true">
-                </a>
-
-                <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                    <li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#test-modal-{{ $tweet->id }}" href="#">編集する</a></li>
-                    <li><a class="dropdown-item text-danger" href="#">削除する</a></li>
-                </ul>
-            </div>
-            <div id="test-modal-{{ $tweet->id }}" class="modal fade" tabindex="-1" aria-hidden="true">
-                <div class="modal-dialog">
-                    <div class="modal-content update-modal">
-                        <div class="modal-header">
-                            <h5 class="modal-title">ツイート編集</h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                        </div>
-                        <div class="modal-body">
-                            <form id="update-{{ $tweet->id }}" method="POST" action="{{ route('tweets.update', $tweet->id) }}">
-                                @csrf
-                                <textarea class="tweet-textarea" type="text" id="tweet" name="tweet">{{ $tweet->tweet }}</textarea>
-                            </form>
-                        </div>
-                        <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
-                            <button type="submit" form="update-{{ $tweet->id }}" class="btn btn-primary" data-bs-dismiss="modal">更新する</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            @endif
-        </div>
+        @include('components.tweet-card')
     </a>
-        @endforeach
+    @endforeach
 </body>
 @endsection

--- a/twitter/resources/views/tweets/show.blade.php
+++ b/twitter/resources/views/tweets/show.blade.php
@@ -3,49 +3,7 @@
 
 <body>
     <h1>ツイート詳細</h1>
-    <div class="card tweet-card text-dark bg-light mb-3">
-        <div class="card-body">
-            <p class="card-title fw-bolder">{{ $tweetInfo->user->name}}<span class="text-secondary">{{ $tweetInfo->created_at }}</span></p>
-            <p class="card-text">
-                {{ $tweetInfo->tweet }}
-                @if ($tweetInfo->updated_at != $tweetInfo->created_at)
-                <small class="text-secondary">（編集済み）</small>
-                @endif
-            </p>
-        </div>
-        @if (Auth::id() === $tweetInfo->user->id)
-        <div class="tweet-dropdown">
-            <a class="dots-leader" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="true">
-            </a>
-
-            <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                <li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#test-modal-{{ $tweetInfo->id }}" href="#">編集する</a></li>
-                <li><a class="dropdown-item text-danger" href="#">削除する</a></li>
-            </ul>
-        </div>
-        <div id="test-modal-{{ $tweetInfo->id }}" class="modal fade" tabindex="-1" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content update-modal">
-                    <div class="modal-header">
-                        <h5 class="modal-title">ツイート編集</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <form id="update-{{ $tweetInfo->id }}" method="POST" action="{{ route('tweets.update', $tweetInfo->id) }}">
-                            @csrf
-                            <textarea class="tweet-textarea" type="text" id="tweet" name="tweet">{{ $tweetInfo->tweet }}</textarea>
-                        </form>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
-                        <button type="submit" form="update-{{ $tweetInfo->id }}" class="btn btn-primary" data-bs-dismiss="modal">更新する</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        @endif
-    </div>
+    @include('components.tweet-card')
 </body>
 
 @endsection

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -34,4 +34,5 @@ Route::group(['middleware' => 'auth'], function () {
     Route::get('/tweets', [App\Http\Controllers\TweetController::class, 'index'])->name('tweets.index');
     Route::get('/tweets/{id}', [App\Http\Controllers\TweetController::class, 'findByTweetId'])->name('tweets.show');
     Route::post('/tweets/{id}', [App\Http\Controllers\TweetController::class, 'update'])->name('tweets.update');
+    Route::delete('/tweets/{id}', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweets.delete');
 });


### PR DESCRIPTION
ツイートを論理削除できるようにしました。
以下の変更を加えました。

・ツイート削除、ユーザー削除を処理をモデルに記述。
・ツイート部分がツイート一覧、ツイート詳細で共通していたので、components/tweet-cardに切り分けて共通化した。