### PR TITLE
いいねしたツイート一覧を表示

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -96,4 +96,20 @@ class TweetController extends Controller
         ];
         return response()->json($json);
     }
+
+    /**
+     * いいねした投稿全てを表示
+     * 
+     * @param int $userId
+     * @return View
+     */
+    public function showAllFavoriteTweets(int $userId): View
+    {
+        $tweet = new Tweet();
+        $AllFavoriteTweets = $tweet->getAllFavoriteTweets($userId);
+        foreach ($AllFavoriteTweets as $tweet) {
+            $tweet->isFavorite = $tweet->isFavorite($userId);
+        }
+        return view('tweets.favorite', compact('AllFavoriteTweets'));
+    }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -26,6 +26,7 @@ class TweetController extends Controller
         foreach ($allTweets as $tweet) {
             $tweet->isFavorite = $tweet->isFavorite($userId);
         }
+        
         return view('tweets.index', compact('allTweets', 'keyword'));
     }
 
@@ -44,6 +45,7 @@ class TweetController extends Controller
     {
         $tweet = new Tweet();
         $tweet->saveTweet($request);
+
         return redirect()->route('tweets.index');
     }
 
@@ -67,6 +69,7 @@ class TweetController extends Controller
     {
         $tweet = new Tweet();
         $tweet->updateTweet($tweetId, $request);
+
         return redirect()->route('tweets.index');
     }
 
@@ -77,6 +80,7 @@ class TweetController extends Controller
     {
         $tweet = new Tweet();
         $tweet->deleteTweet($tweetId);
+
         return redirect()->route('tweets.index');
     }
 
@@ -94,6 +98,7 @@ class TweetController extends Controller
         $json = [
             'tweetFavoritesCount' => $tweetFavoritesCount,
         ];
+
         return response()->json($json);
     }
 
@@ -109,6 +114,7 @@ class TweetController extends Controller
         foreach ($AllFavoriteTweets as $tweet) {
             $tweet->isFavorite = $tweet->isFavorite($userId);
         }
+
         return view('tweets.favorite', compact('AllFavoriteTweets'));
     }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -103,9 +103,8 @@ class TweetController extends Controller
      * @param int $userId
      * @return View
      */
-    public function showAllFavoriteTweets(int $userId): View
+    public function showAllFavoriteTweets(Tweet $tweet, int $userId): View
     {
-        $tweet = new Tweet();
         $AllFavoriteTweets = $tweet->getAllFavoriteTweets($userId);
         foreach ($AllFavoriteTweets as $tweet) {
             $tweet->isFavorite = $tweet->isFavorite($userId);

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
-
+use App\Models\User;
 
 class Tweet extends Model
 {
@@ -114,4 +114,19 @@ class Tweet extends Model
             $this->favorites()->attach($userId);
         }
     }
+
+    /**
+     * いいねしたツイートを全て取得
+     * 
+     * @param int $userId
+     * @return Collection
+     */
+    public function getAllFavoriteTweets(int $userId): Collection
+    {
+        $user = new User();
+        $userInfo = $user->findByUserId($userId);
+        $AllFavoriteTweets = $userInfo->favorites;
+        return $AllFavoriteTweets;
+    }
+
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -2,14 +2,14 @@
 
 namespace App\Models;
 
-use Illuminate\Http\Request;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use App\Models\User;
 
 class Tweet extends Model
 {
@@ -126,6 +126,7 @@ class Tweet extends Model
         $user = new User();
         $userInfo = $user->findByUserId($userId);
         $AllFavoriteTweets = $userInfo->favorites;
+        
         return $AllFavoriteTweets;
     }
 

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -91,6 +91,7 @@ class Tweet extends Model
             foreach($keywordArray as $keyword) {
                 $searchdTweet = Tweet::orWhere('tweet', 'like', "%$keyword%")->get();
             }
+
             return $searchdTweet;
         }
     }
@@ -108,11 +109,9 @@ class Tweet extends Model
      */
     public function favoriteTweet(int $userId): void
     {
-        if($this->isFavorite($userId)) {
-            $this->favorites()->detach($userId);
-        } else {
-            $this->favorites()->attach($userId);
-        }
+        $this->isFavorite($userId) 
+            ? $this->favorites()->detach($userId) 
+            : $this->favorites()->attach($userId);
     }
 
     /**

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -59,18 +59,33 @@ class User extends Authenticatable
     // followersテーブルにリレーション張る（フォローしている人を取得）
     public function follows(): BelongsToMany
     {
-        return $this->belongsToMany('App\Models\User', 'followers', 'follow_user_id', 'follower_user_id');
+        return $this->belongsToMany(
+            'App\Models\User', 
+            'followers', 
+            'follow_user_id', 
+            'follower_user_id'
+        );
     }
 
     // followersテーブルにリレーション張る（自分のことをフォローしている人を取得）
     public function followers(): BelongsToMany
     {
-        return $this->belongsToMany('App\Models\User', 'followers', 'follower_user_id', 'follow_user_id');
+        return $this->belongsToMany(
+            'App\Models\User', 
+            'followers', 
+            'follower_user_id', 
+            'follow_user_id'
+        );
     }
 
     // favoritesテーブルにリレーション張る
     public function favorites(): BelongsToMany {
-        return $this->belongsToMany('App\Models\Tweet', 'favorites', 'user_id', 'tweet_id');
+        return $this->belongsToMany(
+            'App\Models\Tweet', 
+            'favorites', 
+            'user_id', 
+            'tweet_id'
+        );
     }
 
     /**

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -68,6 +68,11 @@ class User extends Authenticatable
         return $this->belongsToMany('App\Models\User', 'followers', 'follower_user_id', 'follow_user_id');
     }
 
+    // favoritesテーブルにリレーション張る
+    public function favorites(): BelongsToMany {
+        return $this->belongsToMany('App\Models\Tweet', 'favorites', 'user_id', 'tweet_id');
+    }
+
     /**
      * 特定のユーザーを取得
      */

--- a/twitter/resources/views/tweets/favorite.blade.php
+++ b/twitter/resources/views/tweets/favorite.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+@section('content')
+
+<body>
+    <h1>いいねしたツイート</h1>
+    @if($AllFavoriteTweets->isEmpty())
+        <p>いいねされたツイートはまだありません</p>
+    @endif
+    @foreach ($AllFavoriteTweets as $tweet)
+    <a class="text-decoration-none tweet-card-link" href="{{ route('tweets.show', ['id' => $tweet->id]) }}">
+        @include('components.tweet-card')
+    </a>
+    @endforeach
+</body>
+@endsection

--- a/twitter/resources/views/tweets/favorite.blade.php
+++ b/twitter/resources/views/tweets/favorite.blade.php
@@ -7,7 +7,10 @@
         <p>いいねされたツイートはまだありません</p>
     @endif
     @foreach ($AllFavoriteTweets as $tweet)
-    <a class="text-decoration-none tweet-card-link" href="{{ route('tweets.show', ['id' => $tweet->id]) }}">
+    <a 
+        class="text-decoration-none tweet-card-link" 
+        href="{{ route('tweets.show', ['id' => $tweet->id]) }}"
+    >
         @include('components.tweet-card')
     </a>
     @endforeach

--- a/twitter/resources/views/users/show.blade.php
+++ b/twitter/resources/views/users/show.blade.php
@@ -27,6 +27,12 @@
             {{ $userInfo->follows->count() }}フォロー
         </a>
     </p>
+    <p class="border-bottom">
+        いいね:
+        <a href="{{ route('tweets.favorites', ['id' => $userInfo->id]) }}">
+            {{ $userInfo->favorites->count() }}いいね
+        </a>
+    </p>
 </div>
 
 <body>

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -24,22 +24,26 @@ Auth::routes();
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
 
 Route::group(['middleware' => 'auth'], function () {
-    Route::get('/users', [App\Http\Controllers\UserController::class, 'showAllUsers'])->name('users.index');
-    Route::get('/users/{id}', [App\Http\Controllers\UserController::class, 'findByUserId'])->name('users.show');
-    Route::put('/users/{id}', [App\Http\Controllers\UserController::class, 'update'])->name('users.update');
-    Route::delete('/users/{id}', [App\Http\Controllers\UserController::class, 'delete'])->name('users.delete');
-    Route::post('/users/follow/{id}', [App\Http\Controllers\UserController::class, 'follow'])->name('users.follow');
-    Route::post('/users/unfollow/{id}', [App\Http\Controllers\UserController::class, 'unfollow'])->name('users.unfollow');
-    Route::get('/users/followers/{id}', [App\Http\Controllers\UserController::class, 'showAllfollowers'])->name('users.followers');
-    Route::get('/users/follows/{id}', [App\Http\Controllers\UserController::class, 'showAllfollows'])->name('users.follows');
+    Route::group(['prefix' => 'users', 'as' => 'users.'], function() {
+        Route::get('/', [App\Http\Controllers\UserController::class, 'showAllUsers'])->name('index');
+        Route::get('{id}', [App\Http\Controllers\UserController::class, 'findByUserId'])->name('show');
+        Route::put('{id}', [App\Http\Controllers\UserController::class, 'update'])->name('update');
+        Route::delete('{id}', [App\Http\Controllers\UserController::class, 'delete'])->name('delete');
+        Route::post('follow/{id}', [App\Http\Controllers\UserController::class, 'follow'])->name('follow');
+        Route::post('unfollow/{id}', [App\Http\Controllers\UserController::class, 'unfollow'])->name('unfollow');
+        Route::get('followers/{id}', [App\Http\Controllers\UserController::class, 'showAllfollowers'])->name('followers');
+        Route::get('follows/{id}', [App\Http\Controllers\UserController::class, 'showAllfollows'])->name('follows');    
+    });
 
-    Route::get('/tweets/create', [App\Http\Controllers\TweetController::class, 'create'])->name('tweets.create');
-    Route::post('/tweets', [App\Http\Controllers\TweetController::class, 'store'])->name('tweets.store');
-    Route::get('/tweets', [App\Http\Controllers\TweetController::class, 'index'])->name('tweets.index');
-    Route::get('/tweets/{id}', [App\Http\Controllers\TweetController::class, 'findByTweetId'])->name('tweets.show');
-    Route::post('/tweets/{id}', [App\Http\Controllers\TweetController::class, 'update'])->name('tweets.update');
-    Route::delete('/tweets/{id}', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweets.delete');
-    Route::get('/tweets/search', [App\Http\Controllers\TweetController::class, 'search'])->name('tweets.search');
-    Route::post('/tweets/favorite/{id}', [App\Http\Controllers\TweetController::class, 'favorite'])->name('tweets.favorite');
-    Route::get('/tweets/favorite/{id}', [App\Http\Controllers\TweetController::class, 'showAllFavoriteTweets'])->name('tweets.favorites');
+    Route::group(['prefix' => 'tweets', 'as' => 'tweets.'], function() {
+        Route::post('/', [App\Http\Controllers\TweetController::class, 'store'])->name('store');
+        Route::get('/', [App\Http\Controllers\TweetController::class, 'index'])->name('index');
+        Route::get('create', [App\Http\Controllers\TweetController::class, 'create'])->name('create');
+        Route::get('{id}', [App\Http\Controllers\TweetController::class, 'findByTweetId'])->name('show');
+        Route::post('{id}', [App\Http\Controllers\TweetController::class, 'update'])->name('update');
+        Route::delete('{id}', [App\Http\Controllers\TweetController::class, 'delete'])->name('delete');
+        Route::get('search', [App\Http\Controllers\TweetController::class, 'search'])->name('search');
+        Route::post('favorite/{id}', [App\Http\Controllers\TweetController::class, 'favorite'])->name('favorite');
+        Route::get('favorite/{id}', [App\Http\Controllers\TweetController::class, 'showAllFavoriteTweets'])->name('favorites');    
+    });
 });

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -41,4 +41,5 @@ Route::group(['middleware' => 'auth'], function () {
     Route::delete('/tweets/{id}', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweets.delete');
     Route::get('/tweets/search', [App\Http\Controllers\TweetController::class, 'search'])->name('tweets.search');
     Route::post('/tweets/favorite/{id}', [App\Http\Controllers\TweetController::class, 'favorite'])->name('tweets.favorite');
+    Route::get('/tweets/favorite/{id}', [App\Http\Controllers\TweetController::class, 'showAllFavoriteTweets'])->name('tweets.favorites');
 });


### PR DESCRIPTION
# 課題のリンク
- いいねした投稿一覧が見られる

# 関連チケット

# 改修内容
-userモデルでいいねテーブルに対してリレーションを張りました
-Tweetモデルにいいねしたツイートを全て取得するgetAllFavoriteTweets関数を作成
-Tweetコントローラーに全ての投稿をブレードに渡すためのshowAllFavoriteTweets関数を作成
-いいねしたツイート一覧を表示させるためのfavorite.blade.phpを作成
-ユーザー詳細画面からいいねしたツイートを見れるようにしました

# キャプチャ

# 検証内容
- <!-- 改修後それをどうやって検証したか -->
-ツイート一覧ページを見て表示されているかを確認しました
-いいねを付けたり外したりしてツイート一覧に変化があるかを確認しました。

# 相談事項
- <!-- 相談事項があれば書いてください -->

# 注意事項
- なし